### PR TITLE
Env + Readme Fixes

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,9 +1,11 @@
+name: css-preflight
 services:
   node:
     build:
       context: .
       dockerfile: ./node.Dockerfile
-    image: localhost/css-preflight_devcontainer-node:latest
+    image: localhost/css-preflight-devcontainer-node:latest
+    container_name: css-preflight-devcontainer
     userns_mode: "keep-id"
     volumes:
       - ../:/home/node/css-preflight

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,13 +8,10 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "esbenp.prettier-vscode",
         "bierner.markdown-preview-github-styles"
       ],
       "settings": {
         "[markdown]": {
-          "editor.defaultFormatter": "esbenp.prettier-vscode",
-          "editor.formatOnSave": true,
           "editor.wordWrap": "off"
         }
       }

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -22,19 +22,10 @@ jobs:
       - name: Code Checks
         uses: ./.github/composite-actions/code-checks
 
-      - name: 1Password Load Tokens
-        id: op-tokens
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          NPM_TOKEN: op://dev/css-preflight/GITHUB_ACTIONS_NPM_TOKEN
-
       - name: Release Pull Request or Publish to NPM
         uses: changesets/action@v1
         with:
           publish: pnpm changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: set in steps.op-tokens (export-env: true)
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .pnpm-store
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # css-preflight
 
+## 2.0.1
+
+### Patch Changes
+
+- Small Readme Fixes
+
 ## 2.0.0
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ other utilities are also provided.
 
 ## Differences to Tailwind's Preflight
 
-The following adjustments have been made to to the preflight:
+The following adjustments have been made to the preflight:
 
 1. Tailwind-specific CSS variables and styling removed.
 2. Two Tailwind `font-family` defaults have been removed from the
    preflight in favor of optional imports. One was setting the
-   default font stack for the overall html document, and the other
-   was setting monospace fonts for html elements like `code`.
+   default font stack for the overall HTML document, and the other
+   was setting monospace fonts for HTML elements like `code`.
 
 #### Why Font Family Defaults Removed
 
@@ -52,10 +52,10 @@ import "css-preflight/preflight.css";
 import "css-preflight/mono-elements.css";
 ```
 
-For fastest performance, it's recommended to have the css directly
-injected into the html as a `<style>` tag, along with any other critical
-css applying to above-the-fold content. Avoid putting the `<style>` tag
-inside `<head>` as invalid css can break processing of other elements
+For fastest performance, it's recommended to have the CSS directly
+injected into the HTML as a `<style>` tag, along with any other critical
+CSS applying to above-the-fold content. Avoid putting the `<style>` tag
+inside `<head>` as invalid CSS can break processing of other elements
 inside `<head>`.
 
 ```html
@@ -64,7 +64,7 @@ inside `<head>`.
   <style>
     <!-- Inject here -->
   </style>
-  <!-- rest of html -->
+  <!-- Rest of html -->
 </body>
 ```
 
@@ -76,9 +76,9 @@ font stacks:
 :host {
   font-family:
     /* Your fonts here */
+    sans-serif, /* or serif, monospace, etc. */
     /* then do: */
-    sans-serif,
-    /* or serif, or monospace, etc. */ "Apple Color Emoji",
+    "Apple Color Emoji",
     "Segoe UI Emoji",
     "Segoe UI Symbol",
     "Noto Color Emoji";
@@ -129,9 +129,9 @@ import "css-preflight/font-serif.css";
 
 ### Mono Elements
 
-Sets a default mono font stack for the `code`, `kbd`, `samp`, and `pre`
-html elements. Many design and branding systems don't include
-mono font guidelines so this option can be useful for those cases.
+Sets a default monospace font stack for the `code`, `kbd`, `samp`, and `pre`
+HTML elements. Many design and branding systems don't include
+monospace font guidelines so this option can be useful for those cases.
 
 ```javascript
 import "css-preflight/mono-elements.css";
@@ -139,12 +139,10 @@ import "css-preflight/mono-elements.css";
 
 ### Rem Same Px
 
-Sets `1 rem = 1px` at the root for easier design-dev handoff. This calculation is done
-using `%`, so if the user adjusts the browser font sizes, those will still affect the page
-for accessibility purposes.
-
-Can sometimes mess up dev environment error messages though (the error UI becomes very,
-very small). That can be fixed of course, but just an FYI.
+Sets `1 rem = 1px` at the root for easier design-dev hand-off. This calculation
+is done using `%`, so if the user adjusts the browser font sizes, those will
+still affect the page for accessibility purposes. Note this may affect
+framework error debug message pages in development (e.g. Nuxt, Next, Astro, etc.).
 
 ```javascript
 import "css-preflight/rem-same-px.css"; // styles/rem-same-px.css

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "css-preflight",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "license": "MIT",
   "description": "CSS browser reset based on Tailwind's preflight, with optional enhancements.",


### PR DESCRIPTION
* Remove Prettier from formatting Readme
* Remove 1Password CLI from deployment pipeline
* Explicit container names for devcontainer
* Readme typo fixes and improvements
* Smaller env fixes